### PR TITLE
Added chrome.google.com domain.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 * [www.google.ma](https://www.google.ma)
 * [www.google.pt](https://www.google.pt)
 * [www.google.tn](https://www.google.tn)
+* [chrome.google.com](https://chrome.google.com)
 
 ## How to install it
 **Google Consent Bypass** is not available on *Chrome Web Store*, you have to install it manually:

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -44,7 +44,8 @@
     "*://www.google.lu/",
     "*://www.google.ma/",
     "*://www.google.pt/",
-    "*://www.google.tn/"
+    "*://www.google.tn/",
+    "*://chrome.google.com/"
   ],
   "content_scripts": [
     {
@@ -66,7 +67,8 @@
         "*://www.google.lu/*",
         "*://www.google.ma/*",
         "*://www.google.pt/*",
-        "*://www.google.tn/*"
+        "*://www.google.tn/*",
+        "*://chrome.google.com/*"
       ],
       "run_at": "document_start",
       "js": [


### PR DESCRIPTION
I had an issue with the Google login captcha prompt for checking the chrome webstore on the Brave browser.
Since I habitually had used mirror or proxy services for YouTube for example to counter-act this issue, I tried to found a way to pass it.
Not founding a practical store mirror (Had found updaters for the ungoogled-chromium project, but I actually wanted something to access the store in itself), I’ve stumbled upon your extension dedicated to pass those horrible full page consents prompts.
It was, actually, far easier to bypass the Chrome web store, as I just had to edit the manifest to include the chrome webstore domain.